### PR TITLE
[RFC] Add std::chrono timer for iteration loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ CSRCS = propagate-toz-test_CUDA.cu
 #CSRCS = propagate-toz-test_CUDA_v2.cu
 ifeq ($(COMPILER),nvcc)
 CXX=nvcc
-CFLAGS1 += -arch=sm_70 -O3 -DUSE_GPU --default-stream per-thread
+CFLAGS1 += -arch=sm_70 -O3 -DUSE_GPU --default-stream per-thread -std=c++11
 CLIBS1 += -L${CUDALIBDIR} -lcudart 
 endif
 endif
@@ -179,7 +179,7 @@ ifeq ($(MODE),cudav2)
 CSRCS = propagate-toz-test_CUDA_v2.cu
 ifeq ($(COMPILER),nvcc)
 CXX=nvcc
-CFLAGS1 += -arch=sm_70 -O3 -DUSE_GPU --default-stream per-thread -maxrregcount 64
+CFLAGS1 += -arch=sm_70 -O3 -DUSE_GPU --default-stream per-thread -maxrregcount 64 -std=c++11
 CLIBS1 += -L${CUDALIBDIR} -lcudart 
 endif
 endif

--- a/src_complete/kokkos_src/ptoz_kokkos.cpp
+++ b/src_complete/kokkos_src/ptoz_kokkos.cpp
@@ -6,6 +6,10 @@
 #include <unistd.h>
 #include <sys/time.h>
 
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
 // kokkos
 #include <Kokkos_Core.hpp>
 // our typedefs curtisy of the examples
@@ -109,12 +113,18 @@ int main( int argc, char* argv[] )
   convert_in_t = get_time();
   
 
+  auto wall_start = std::chrono::high_resolution_clock::now();
   for(itr=0; itr<NITER; itr++) {
   
       propagateToZ(all_tracks, all_hits, all_out, errorProp, temp);
       update(all_out, all_hits);
 
   } // end of itr loop
+  Kokkos::fence();
+  auto wall_stop = std::chrono::high_resolution_clock::now();
+  auto wall_diff = wall_stop - wall_start;
+  auto wall_time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+  std::cout << "Wall clock time " << std::scientific << wall_time << " s" << std::endl;
 
   p2z_t = get_time();
 

--- a/src_complete/propagate-toz-test_CUDA.cu
+++ b/src_complete/propagate-toz-test_CUDA.cu
@@ -9,6 +9,10 @@ icc propagate-toz-test.C -o propagate-toz-test.exe -fopenmp -O3
 #include <unistd.h>
 #include <sys/time.h>
 
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
 #ifndef nevts
 #define nevts 100
 #endif
@@ -664,6 +668,8 @@ int main (int argc, char* argv[]) {
   gettimeofday(&timecheck, NULL);
   start_wall = (long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000;
   cudaEventRecord(start);	
+
+  auto wall_start = std::chrono::high_resolution_clock::now();
   for(int itr=0; itr<NITER; itr++){
   cudaEventRecord(startcopy);	
   cudaEventSynchronize(startcopy);
@@ -722,6 +728,11 @@ int main (int argc, char* argv[]) {
   copybacktime += copybacktime_itr;
   } //end itr loop
   cudaDeviceSynchronize(); // shaves a few seconds
+  auto wall_stop = std::chrono::high_resolution_clock::now();
+  auto wall_diff = wall_stop - wall_start;
+  auto wall_time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+  std::cout << "Wall clock time " << std::scientific << wall_time << " s" << std::endl;
+
   cudaEventRecord(end);
   cudaEventSynchronize(end);
   gettimeofday(&timecheck, NULL);

--- a/src_complete/propagate-toz-test_CUDA_v2.cu
+++ b/src_complete/propagate-toz-test_CUDA_v2.cu
@@ -10,6 +10,10 @@ icc propagate-toz-test.C -o propagate-toz-test.exe -fopenmp -O3
 #include <sys/time.h>
 #include <iostream>
 
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
 #ifndef nevts
 #define nevts 100
 #endif
@@ -750,6 +754,7 @@ int main (int argc, char* argv[]) {
  // start_wall = (long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000;
 
 
+  auto wall_start = std::chrono::high_resolution_clock::now();
   for(itr=0; itr<NITER; itr++){
     //  transfer(trk,hit, trk_dev,hit_dev);
   //cudaEventRecord(startcopy);	
@@ -841,6 +846,11 @@ int main (int argc, char* argv[]) {
   } //end itr loop
   
   cudaDeviceSynchronize(); 
+  auto wall_stop = std::chrono::high_resolution_clock::now();
+  auto wall_diff = wall_stop - wall_start;
+  auto wall_time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+  std::cout << "Wall clock time " << std::scientific << wall_time << " s" << std::endl;
+
 //  gettimeofday(&timecheck, NULL);
 //  end_wall = (long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000;
   cudaEventRecord(end);


### PR DESCRIPTION
This PR shows how I used the `std::chrono::high_resolution_clock` in the two CUDA programs and in the Kokkos program.

For the actual tests I changed the Kokkos program to use `Cuda` execution space and `CudaUVMSpace` memory space, and 
```diff
-#define NITER 100
+#define NITER 5
```
in `src_complete/kokkos_src/ptoz_data.h`.

I'm not sure if we want to merge this as-is, or include as part of the more general clean-up (hence RFC and draft PR).